### PR TITLE
Fix binaries for Linux

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 const oclif = require('@oclif/core')
 

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 const oclif = require('@oclif/core')
 


### PR DESCRIPTION
By default the `env` command consideres the entire argument string to be the binary, causing these to fail because "node --no-warnings" is not a binary.

https://unix.stackexchange.com/questions/63979/shebang-line-with-usr-bin-env-command-argument-fails-on-linux