### PR TITLE
Adding a EVENTLY_BOOKMARK environment variable

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -37,7 +37,7 @@ export function initClient(token: string): Client {
     })
   }
 
-  client = new Client('https://preview.evently.cloud/')
+  client = new Client(process.env.EVENTLY_BOOKMARK ?? 'https://preview.evently.cloud/')
   client.use(bearerAuth(token))
   client.use( async( req, next) => {
 


### PR DESCRIPTION
This lets uses set the 'host'.

Why bookmark and not host? In HATEOAS this term is used as the endpoint that a system should remember. It can in theory be at any URL.

If you don't like this and prefer HOST, happy to change it.

Fixes #5 