### PR TITLE
es lint changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,10 @@
   ],
   "rules": {
       "indent": ["error", 2, {
-        "SwitchCase": 1
+        "SwitchCase": 1,
+        "FunctionDeclaration": {
+          "parameters": "first"
+        }
       }],
       "linebreak-style": ["error", "unix"],
       "no-constant-condition": ["error", {
@@ -50,7 +53,15 @@
         "assertionStyle": "as",
         "objectLiteralTypeAssertions": "never"
       }],
-      "@typescript-eslint/member-delimiter-style": "error",
+      "@typescript-eslint/member-delimiter-style": ["error", {
+        "multiline": {
+          "delimiter": "none"
+        },
+        "singleline": {
+          "delimiter": "semi",
+          "requireLast": false
+        }
+      }],
       "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/no-explicit-any" : 0,
       "@typescript-eslint/no-for-in-array": "error",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@oclif/plugin-commands": "2.2",
     "@oclif/plugin-help": "5.2",
     "@oclif/plugin-not-found": "2.3",
-    "ketting": "^8.0.0-alpha.1"
+    "ketting": "8.0.0-alpha.2"
   },
   "devDependencies": {
     "@oclif/test": "^2.3.7",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,7 +7,7 @@ import {TokenAwareCommand} from './token-command'
  */
 let client: Client|null = null
 
-type FetchMiddleware = (req: Request) => Promise<Response> | Response;
+type FetchMiddleware = (req: Request) => Promise<Response> | Response
 let mockCallback: FetchMiddleware | null = null
 
 /**
@@ -75,7 +75,7 @@ export async function followByName(parent: Resource, name: string): Promise<Reso
 /**
  * Sets a callback that globally intercepts all HTTP traffic.
  *
- * This is used for unittesting.
+ * This is used for unit testing.
  */
 export function setMockCallback(cb: FetchMiddleware) {
 

--- a/src/lib/download/types.ts
+++ b/src/lib/download/types.ts
@@ -1,19 +1,19 @@
 export type UnknownObject = {
-  [k: string]: unknown;
+  [k: string]: unknown
 }
 
 export interface EventBody {
-  entity: string;
-  key: string;
-  event: string;
-  eventId: string;
-  timestamp: string;
-  meta: UnknownObject;
-  data: any;
+  entity:     string
+  key:        string
+  event:      string
+  eventId:    string
+  timestamp:  string
+  meta:       UnknownObject
+  data:       any
 }
 
 export interface ValidationContext {
-  ledgerId: string;
-  count: number;
-  previousEventId: string;
+  ledgerId:         string
+  count:            number
+  previousEventId:  string
 }

--- a/src/lib/download/validator.ts
+++ b/src/lib/download/validator.ts
@@ -49,8 +49,8 @@ function calculateLedgerId(firstEvent: EventBody): string {
 
 
 function calculateEventId(eventIn:          EventBody,
-  ledgerIdHex:      string,
-  previousEventId:  string): string {
+                          ledgerIdHex:      string,
+                          previousEventId:  string): string {
   // calculate the base checksum
   let checksum = calculateChecksumWithoutTimestamp(eventIn)
   // add LedgerId

--- a/src/lib/token-command.ts
+++ b/src/lib/token-command.ts
@@ -10,7 +10,7 @@ export abstract class TokenAwareCommand extends Command {
       env:          'EVENTLY_TOKEN',
       required:     false,
       default:      NOT_SET
-    }),
+    })
   }
 
 }

--- a/test/helpers/http.ts
+++ b/test/helpers/http.ts
@@ -8,10 +8,10 @@ async function expectBody(message: Request|Response, body: any) {
 }
 
 type RequestShape = {
-  method: string;
-  path?: string;
-  headers?: Record<string, string>;
-  body?: Record<string, any>;
+  method:   string
+  path?:    string
+  headers?: Record<string, string>
+  body?:    Record<string, any>
 }
 
 /**
@@ -37,11 +37,11 @@ export async function expectRequest(request: Request, shape: RequestShape) {
 
 
 type ResponseOptions = {
-  status?: number;
-  body?: Record<string, any>;
-  links?: Omit<Link,'context'>[];
-  headers?: Record<string,string>;
-};
+  status?:  number
+  body?:    Record<string, any>
+  links?:   Omit<Link, 'context'>[]
+  headers?: Record<string, string>
+}
 
 /**
  * A function to make building HTTP responses a bit easier.

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,5 +1,5 @@
-process.env.TS_NODE_PROJECT = require("path").resolve("test/tsconfig.json")
-process.env.NODE_ENV = "development"
+process.env.TS_NODE_PROJECT = require('path').resolve('test/tsconfig.json')
+process.env.NODE_ENV = 'development'
 
 global.oclif = global.oclif || {}
 global.oclif.columns = 80


### PR DESCRIPTION
Changed indenting for multi-param method declarations to line up on first param.

Removed more `;` delimiters.
double-quoted strings in JS files.