### PR TITLE
selector:replay command

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,21 +380,21 @@ Replay an entities events.
 
 ```
 USAGE
-  $ evently selector:replay -n <value> -k <value> [-t <value>] [-e <value>] [--after <value>] [--limit <value>]
-    [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output csv|json|yaml |  | [--csv | --no-truncate]]
-    [--no-header | ]
+  $ evently selector:replay -n <value> -k <value> [-t <value>] [-e <value>] [-a <value>] [-l <value>] [--columns
+    <value> | -x] [--sort <value>] [--filter <value>] [--output csv|json|yaml |  | [--csv | --no-truncate]] [--no-header
+    | ]
 
 FLAGS
+  -a, --after=<value>     Select events that occur after this ledger mark or event ID.
   -e, --event=<value>...  Event name
   -k, --key=<value>...    (required) Entity keys to select for.
+  -l, --limit=<value>     [default: 50] Limit the number of returned events to this value.
   -n, --entity=<value>    (required) Entity name
   -t, --token=<value>     [default: NOT-SET] Access token for your ledger.
   -x, --extended          show extra columns
-  --after=<value>         Select events that occur after this ledger mark or event ID.
   --columns=<value>       only show provided columns (comma-separated)
   --csv                   output is csv format [alias: --output=csv]
   --filter=<value>        filter property by partial string matching, ex: name=foo
-  --limit=<value>         Limit the number of returned events to this value.
   --no-header             hide table header from output
   --no-truncate           do not truncate output to fit screen
   --output=<option>       output in a more machine friendly format

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export EVENTLY_TOKEN="your-token-here"
 * [`evently registry:list-entities`](#evently-registrylist-entities)
 * [`evently registry:list-events`](#evently-registrylist-events)
 * [`evently registry:new`](#evently-registrynew)
+* [`evently selector:replay`](#evently-selectorreplay)
 
 ## `evently append:atomic`
 
@@ -179,7 +180,7 @@ DESCRIPTION
   list all the commands
 ```
 
-_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v2.2.14/src/commands/commands.ts)_
+_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v2.2.15/src/commands/commands.ts)_
 
 ## `evently help [COMMANDS]`
 
@@ -291,6 +292,8 @@ _See code: [dist/commands/registry/delete.ts](https://github.com/evently-cloud/c
 
 ## `evently registry:list-entities`
 
+Lists all entities in the registry.
+
 ```
 USAGE
   $ evently registry:list-entities [-t <value>] [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output
@@ -308,6 +311,9 @@ FLAGS
                        <options: csv|json|yaml>
   --sort=<value>       property to sort by (prepend '-' for descending)
 
+DESCRIPTION
+  Lists all entities in the registry.
+
 EXAMPLES
   $ evently registry:list-entities
 ```
@@ -315,6 +321,8 @@ EXAMPLES
 _See code: [dist/commands/registry/list-entities.ts](https://github.com/evently-cloud/cli/blob/v0.3.0/dist/commands/registry/list-entities.ts)_
 
 ## `evently registry:list-events`
+
+Lists all event types for an entity.
 
 ```
 USAGE
@@ -333,6 +341,9 @@ FLAGS
   --output=<option>     output in a more machine friendly format
                         <options: csv|json|yaml>
   --sort=<value>        property to sort by (prepend '-' for descending)
+
+DESCRIPTION
+  Lists all event types for an entity.
 
 EXAMPLES
   $ evently registry:list-events --entity my-entity
@@ -362,4 +373,42 @@ EXAMPLES
 ```
 
 _See code: [dist/commands/registry/new.ts](https://github.com/evently-cloud/cli/blob/v0.3.0/dist/commands/registry/new.ts)_
+
+## `evently selector:replay`
+
+Replay an entities events.
+
+```
+USAGE
+  $ evently selector:replay -n <value> -k <value> [-t <value>] [-e <value>] [--after <value>] [--limit <value>]
+    [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output csv|json|yaml |  | [--csv | --no-truncate]]
+    [--no-header | ]
+
+FLAGS
+  -e, --event=<value>...  Event name
+  -k, --key=<value>...    (required) Entity keys to select for.
+  -n, --entity=<value>    (required) Entity name
+  -t, --token=<value>     [default: NOT-SET] Access token for your ledger.
+  -x, --extended          show extra columns
+  --after=<value>         Select events that occur after this ledger mark or event ID.
+  --columns=<value>       only show provided columns (comma-separated)
+  --csv                   output is csv format [alias: --output=csv]
+  --filter=<value>        filter property by partial string matching, ex: name=foo
+  --limit=<value>         Limit the number of returned events to this value.
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=<option>       output in a more machine friendly format
+                          <options: csv|json|yaml>
+  --sort=<value>          property to sort by (prepend '-' for descending)
+
+DESCRIPTION
+  Replay an entities events.
+
+EXAMPLES
+  $ evently selector:replay   -n article   -e add-comment   -k author
+
+  $ evently selector:replay   -n article   -e add-comment -e delete-comment   -k author, -k date   --limit 10
+```
+
+_See code: [dist/commands/selector/replay.ts](https://github.com/evently-cloud/cli/blob/v0.3.0/dist/commands/selector/replay.ts)_
 <!-- commandsstop -->

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,16 @@
 Changelog
 =========
 
+0.3.2 (????-??-??)
+------------------
+
+* Added selector:replay command
+
+
 0.3.1 (2023-06-11)
 ------------------
 
 * Add a description for list-entities and list-events.
-* Added selector:replay command
 * Fix for ledger:download. This command was broken due to a bug in an
   underlying library.
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 * Add a description for list-entities and list-events.
+* Added selector:replay command
 
 
 0.3.0 (2023-06-05)

--- a/src/commands/registry/list-events.ts
+++ b/src/commands/registry/list-events.ts
@@ -1,7 +1,6 @@
 import { TokenAwareCommand } from '../../lib/token-command'
 import { followByName, initClient } from '../../lib/client'
-import { ux } from '@oclif/core'
-import { Flags } from '@oclif/core'
+import { ux, Flags } from '@oclif/core'
 
 export default class ListEvents extends TokenAwareCommand {
   static description = 'Lists all event types for an entity.'
@@ -38,8 +37,6 @@ export default class ListEvents extends TokenAwareCommand {
       .preferTransclude()
 
     const table: Record<string, string>[] = []
-
-
     for(const event of events) {
 
       const eventState = await event.get()

--- a/src/commands/selector/replay.ts
+++ b/src/commands/selector/replay.ts
@@ -49,9 +49,14 @@ export default class SelectorReplay extends TokenAwareCommand {
     }),
     after: Flags.string({
       description: 'Select events that occur after this ledger mark or event ID.',
+      char: 'a',
     }),
     limit: Flags.integer({
       description: 'Limit the number of returned events to this value.',
+      char: 'l',
+      default: 50,
+      min: 1,
+      max: 5000,
     }),
     ...TokenAwareCommand.flags,
     ...ux.table.flags(),

--- a/src/commands/selector/replay.ts
+++ b/src/commands/selector/replay.ts
@@ -114,8 +114,9 @@ export default class SelectorReplay extends TokenAwareCommand {
       flags,
     )
 
+    this.log('')
     if ('next' in meta._links) {
-      this.log('Next page: %s', meta._links.href)
+      this.log('Next page: %s', meta._links.next.href)
     } else {
       this.log('No more data')
     }

--- a/src/commands/selector/replay.ts
+++ b/src/commands/selector/replay.ts
@@ -16,18 +16,17 @@ type ReplayEvent = {
 export default class SelectorReplay extends TokenAwareCommand {
   static description = 'Replay an entities events.'
 
+  /* eslint-disable quotes */
   static examples = [
     `$ evently selector:replay \
   -n article \
   -e add-comment \
-  -k author
-`,
+  -k author`,
     `$ evently selector:replay \
   -n article \
   -e add-comment -e delete-comment \
   -k author, -k date \
-  --limit 10
-`,
+  --limit 10`,
   ]
 
   static flags = {

--- a/src/commands/selector/replay.ts
+++ b/src/commands/selector/replay.ts
@@ -1,0 +1,125 @@
+import {TokenAwareCommand} from '../../lib/token-command'
+import {initClient} from '../../lib/client'
+import { ux, Flags } from '@oclif/core'
+
+
+type ReplayEvent = {
+  entity: string
+  key: string
+  event: string
+  eventId: string
+  timestamp: string
+  meta: Record<string, string>
+  data: Record<string, any>
+}
+
+export default class SelectorReplay extends TokenAwareCommand {
+  static description = 'Replay an entities events.'
+
+  static examples = [
+    `$ evently selector:replay \
+  -n article \
+  -e add-comment \
+  -k author
+`,
+    `$ evently selector:replay \
+  -n article \
+  -e add-comment -e delete-comment \
+  -k author, -k date \
+  --limit 10
+`,
+  ]
+
+  static flags = {
+    entity: Flags.string({
+      char:         'n',
+      description:  'Entity name',
+      required:     true,
+    }),
+    event: Flags .string({
+      char:         'e',
+      description:  'Event name',
+      required:     false,
+      multiple:     true,
+    }),
+    key: Flags.string({
+      char:         'k',
+      description:  'Entity keys to select for.',
+      required:     true,
+      multiple:     true,
+    }),
+    after: Flags.string({
+      description: 'Select events that occur after this ledger mark or event ID.',
+    }),
+    limit: Flags.integer({
+      description: 'Limit the number of returned events to this value.',
+    }),
+    ...TokenAwareCommand.flags,
+    ...ux.table.flags(),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(SelectorReplay)
+
+    const client = initClient(flags.token)
+
+    const replayRes = await client
+      .follow('selectors')
+      .follow('replay')
+
+    const result = await replayRes.post({
+      data: {
+        entity: flags.entity,
+        events: flags.event,
+        keys: flags.key,
+        limit: flags.limit,
+        after: flags.after,
+      }
+    })
+
+    const records = []
+    const lines = (await result.data.text()).trim().split('\n')
+    for (const record of lines) {
+      records.push(JSON.parse(record))
+    }
+
+    const table:ReplayEvent[] = records.slice(0, -1)
+    const meta = records.at(-1)
+
+    ux.table(
+      table,
+      {
+        entity: {
+          header: 'Entity',
+        },
+        key: {
+          header: 'Key',
+        },
+        event: {
+          header: 'Event',
+        },
+        eventId: {
+          header: 'Event ID',
+        },
+        timestamp: {
+          header: 'Timestamp',
+        },
+        meta: {
+          header: 'Meta',
+        },
+        data: {
+          header: 'Data',
+        }
+      },
+      flags,
+    )
+
+    if ('next' in meta._links) {
+      this.log('Next page: %s', meta._links.href)
+    } else {
+      this.log('No more data')
+    }
+
+  }
+
+}

--- a/test/commands/selector/replay.test.ts
+++ b/test/commands/selector/replay.test.ts
@@ -1,0 +1,114 @@
+import {expect, test} from '@oclif/test'
+
+import { setMockCallback } from '../../../src/lib/client'
+import { buildResponse, expectRequest } from '../../helpers/http'
+const testToken = 'test-token'
+
+describe('selector:replay', async () => {
+
+  before(() => {
+    setMockCallback( (async (req: Request) => {
+
+      expect(req.headers.get('Authorization')).to.equal(`Bearer ${testToken}`)
+      const path = new URL(req.url).pathname
+      let hasNext = false
+      switch(path) {
+        case '/' :
+          return buildResponse({
+            links: [{rel: 'selectors', href: '/s'}]
+          })
+        case '/s' :
+          return buildResponse({
+            links: [
+              {rel: 'replay', href: '/s/r'},
+            ],
+          })
+        case '/s/r' : {
+          await expectRequest(req, {
+            method: 'POST',
+          })
+          const body = await req.json()
+
+          const records = []
+          switch(body.entity) {
+            case 'entity-test1' :
+              records.push({
+                entity: body.entity,
+                key: 'key1',
+                event: 'event1',
+                eventId: 'eventID1',
+                timestamp: '20230610T232900Z',
+                meta: {},
+                data: {},
+              })
+              break
+            case 'entity-test2' :
+              records.push({
+                entity: body.entity,
+                key: 'key1',
+                event: 'event1',
+                eventId: 'eventID1',
+                timestamp: '20230610T232900Z',
+                meta: {},
+                data: {after: body.after},
+              })
+              break
+            case 'entity-test3' :
+              hasNext = true
+              records.push({
+                entity: body.entity,
+                key: 'key1',
+                event: 'event1',
+                eventId: 'eventID1',
+                timestamp: '20230610T232900Z',
+                meta: {},
+                data: {},
+              })
+              break
+          }
+          return buildResponse({
+            headers: {
+              'Content-Type': 'application/x-ndjson',
+            },
+            rawBody: [
+              ...records,
+              {
+                _links: hasNext ? { next: { href: 'https://example/?next'}} : { }
+              },
+            ].map(line => JSON.stringify(line)).join('\n')
+          })
+        }
+        default:
+          return buildResponse({status: 501})
+
+      }
+
+    }))
+
+  })
+
+  test
+    .stdout()
+    .command(['selector:replay', '-t', testToken, '-n', 'entity-test1', '-k', 'key1', '-k', 'key2'])
+    .it('Should succeed with basic arguments', (ctx) => {
+      expect(ctx.stdout).to.contain('Entity')
+      expect(ctx.stdout).to.contain('entity-test1')
+      expect(ctx.stdout).to.contain('Key')
+      expect(ctx.stdout).to.contain('key1')
+      expect(ctx.stdout).to.contain('No more data')
+    })
+  test
+    .stdout()
+    .command(['selector:replay', '-t', testToken, '-n', 'entity-test2', '-k', 'key2', '--after', '123123'])
+    .it('Should pass on the --after argument', (ctx) => {
+      expect(ctx.stdout).to.contain('123123')
+    })
+  test
+    .stdout()
+    .command(['selector:replay', '-t', testToken, '-n', 'entity-test3', '-k', 'key3'])
+    .it('Should show the next link URL', (ctx) => {
+      expect(ctx.stdout).to.contain('https://example/?next')
+    })
+
+})
+


### PR DESCRIPTION
This is now ready for review.

It's missing a feature (showing a command to grab the next page automatically), but I feel that can be addressed in a future PR.

Screenshot from the Help page:

![image](https://github.com/evently-cloud/cli/assets/178960/93445e76-9a1f-490d-b6f2-e48a79e0a51e)

Here's some sample output. This is how oclif formats this, so it's quite tall with the JSON blocks. I feel this needs work:

![image](https://github.com/evently-cloud/cli/assets/178960/a3acb64b-0a03-4f16-aedb-aacaa479442f)

Fixes: #35